### PR TITLE
Note about installing Common C++ tools

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -19,6 +19,8 @@ Building Electron is done entirely with command-line scripts and cannot be done
 with Visual Studio. You can develop Electron with any editor but support for
 building with Visual Studio will come in the future.
 
+When installing Visual Studio you need to include Common C++ tools.
+
 **Note:** Even though Visual Studio is not used for building, it's still
 **required** because we need the build toolchains it provides.
 


### PR DESCRIPTION
Was having trouble building and figured out I needed to install Common C++ tools as part of Visual Studio:
https://stackoverflow.com/questions/33323172/vcvarsall-bat-needed-for-python-to-compile-missing-from-visual-studio-2015-v-1

Worth including in docs?
